### PR TITLE
게시글 좋아요 기능 분리

### DIFF
--- a/src/main/java/com/example/moduhouse/board/controller/BoardController.java
+++ b/src/main/java/com/example/moduhouse/board/controller/BoardController.java
@@ -54,10 +54,17 @@ public class BoardController {
         return new MsgResponseDto(SuccessCode.DELETE_BOARD);
     }
 
-    @PostMapping("/board/like/{boardId}")
+    @PostMapping("/board/{boardId}/boardlike")
     public ResponseEntity<MsgResponseDto> saveBoardLike(
             @PathVariable Long boardId,
             @AuthenticationPrincipal UserDetailsImpl userDetails) {
         return ResponseEntity.ok().body(boardService.saveBoardLike(boardId, userDetails.getUser()));
+    }
+
+    @DeleteMapping("/board/{boardId}/boardCancelLike")
+    public ResponseEntity<MsgResponseDto> saveBoardCancelLike(
+            @PathVariable Long boardId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return ResponseEntity.ok().body(boardService.saveBoardCancelLike(boardId, userDetails.getUser()));
     }
 }

--- a/src/main/java/com/example/moduhouse/board/service/BoardService.java
+++ b/src/main/java/com/example/moduhouse/board/service/BoardService.java
@@ -153,14 +153,22 @@ public class BoardService {
         Board board = boardRepository.findById(boardId).orElseThrow(
                 () -> new CustomException(ErrorCode.NO_BOARD_FOUND)
         );
-        if (!checkBoardLike(boardId, user)) {
+        if(checkBoardLike(boardId,user)){
+            throw new CustomException(ErrorCode.ALREADY_CLICKED_LIKE);
+        }
             boardLikeRepository.saveAndFlush(new BoardLike(board, user));
             return new MsgResponseDto(SuccessCode.LIKE);
-        } else {
-            boardLikeRepository.deleteByBoardIdAndUserId(boardId, user.getId());
-            return new MsgResponseDto(SuccessCode.CANCEL_LIKE);
-        }
     }
 
-
+    @Transactional
+    public MsgResponseDto saveBoardCancelLike(Long boardId, User user) {
+        Board board = boardRepository.findById(boardId).orElseThrow(
+                () -> new CustomException(ErrorCode.NO_BOARD_FOUND)
+        );
+        if(!checkBoardLike(boardId,user)){
+            throw new CustomException(ErrorCode.ALERADY_CANCEL_LIKE);
+        }
+        boardLikeRepository.deleteByBoardIdAndUserId(boardId, user.getId());
+        return new MsgResponseDto(SuccessCode.CANCEL_LIKE);
+    }
 }

--- a/src/main/java/com/example/moduhouse/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/moduhouse/global/exception/ErrorCode.java
@@ -25,7 +25,9 @@ public enum ErrorCode {
     NO_DELETE_COMMENT(HttpStatus.UNAUTHORIZED,"댓글 삭제 권한이 없습니다."),
 
     // CONFLICT
-    DUPLICATE_RESOURCE(HttpStatus.CONFLICT, "데이터가 이미 존재합니다")
+    DUPLICATE_RESOURCE(HttpStatus.CONFLICT, "데이터가 이미 존재합니다"),
+    ALREADY_CLICKED_LIKE(HttpStatus.CONFLICT, "이미 좋아요를 눌렀습니다"),
+    ALERADY_CANCEL_LIKE(HttpStatus.CONFLICT, "이미 좋아요 취소를 눌렀습니다")
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
### PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 코드 리팩토링

### 반영 브랜치
LSH/Board -> dev

### 변경 사항
- 현재 하나로 통합되어 있는 좋아요와 좋아요 취소를,
피드백을 받고 좋아요와 좋아요 취소 두개로 분리
- ErrorCode 좋아요 중복으로 실행했을때의 오류코드 추가

### 테스트 결과
Postman 테스트 결과 이상 없습니다.